### PR TITLE
Rework Configuration to be Slightly More Easy to Understand

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
 name = "embedded-nrf24l01"
-version = "0.2.0"
-authors = ["Astro <astro@spaceboyz.net>"]
+version = "1.0.0"
+authors = ["Astro <astro@spaceboyz.net>", "N8 <n8.wert.b@gmail.com"]
 description = "A driver for NRF24L01(+) transceivers on embedded-hal platforms."
 license = "Apache-2.0"
 categories = ["embedded", "no-std", "hardware-support", "network-programming"]
 keywords = ["driver", "embedded-hal", "wireless", "nrf", "nrf24l01"]
-repository = "https://github.com/astro/embedded-nrf24l01"
-homepage = "https://github.com/astro/embedded-nrf24l01"
+repository = "https://github.com/N8BWert/embedded-nrf24l01"
+homepage = "https://github.com/N8BWert/embedded-nrf24l01"
 edition = "2018"
 
 [dependencies]
 embedded-hal = "0.2.3"
-bitfield = "0.13.2"
-nb = "0.1.2"
+bitfield = "0.14.0"
+nb = "1.1.0"

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,3 @@
-use crate::registers::Config;
 use crate::PIPES_COUNT;
 
 /// Supported air data rates.
@@ -27,18 +26,6 @@ pub enum CrcMode {
     OneByte,
     /// Two bytes checksum
     TwoBytes,
-}
-
-impl CrcMode {
-    fn set_config(&self, config: &mut Config) {
-        let (en_crc, crco) = match *self {
-            CrcMode::Disabled => (false, false),
-            CrcMode::OneByte => (true, false),
-            CrcMode::TwoBytes => (true, true),
-        };
-        config.set_en_crc(en_crc);
-        config.set_crco(crco);
-    }
 }
 
 /// The Power Amplifier Control Level for the nRF24L01 power amplifier (negative)

--- a/src/config.rs
+++ b/src/config.rs
@@ -76,7 +76,7 @@ pub struct NRF24L01Config<'a> {
     /// The pipes that are to be read from
     pub read_enabled_pipes: [bool; PIPES_COUNT],
     /// The addresses to read from (per pipe)
-    pub rx_addr: [&'a [u8]; PIPES_COUNT],
+    pub rx_addrs: [&'a [u8]; PIPES_COUNT],
     /// The address to transmit to
     pub tx_addr: &'a [u8],
     /// At what delay and how many times should data be retransmitted
@@ -99,7 +99,7 @@ impl<'a> NRF24L01Config<'a> {
         pa_level: PALevel,
         interrupt_mask: InterruptMask,
         read_enabled_pipes: [bool; PIPES_COUNT],
-        rx_addr: [&'a [u8]; PIPES_COUNT],
+        rx_addrs: [&'a [u8]; PIPES_COUNT],
         tx_addr: &'a [u8],
         retransmit_config: RetransmitConfig,
         auto_ack_pipes: [bool; PIPES_COUNT],
@@ -113,7 +113,7 @@ impl<'a> NRF24L01Config<'a> {
             pa_level,
             interrupt_mask,
             read_enabled_pipes,
-            rx_addr,
+            rx_addrs,
             tx_addr,
             retransmit_config,
             auto_ack_pipes,
@@ -132,11 +132,11 @@ impl<'a> Default for NRF24L01Config<'a> {
             pa_level: PALevel::PA18dBm,
             interrupt_mask: InterruptMask { data_ready_rx: false, data_sent_tx: false, max_retramsits_tx: false },
             read_enabled_pipes: [false; PIPES_COUNT],
-            rx_addr: [b"rx"; PIPES_COUNT],
+            rx_addrs: [b"rx"; PIPES_COUNT],
             tx_addr: b"tx",
             retransmit_config: RetransmitConfig { delay: 0u8, count: 0u8 },
             auto_ack_pipes: [false; PIPES_COUNT],
-            address_width: 0u8,
+            address_width: 3u8,
             pipe_payload_lengths: [None; PIPES_COUNT],
         }
     }
@@ -174,7 +174,7 @@ pub trait NRF24L01Configuration<'a> {
     fn set_read_enabled_pipes(&mut self, read_enabled_pipes: &[bool; PIPES_COUNT]) -> Result<(), Self::Error>;
 
     /// Sets the read address of a specific pipe
-    fn set_rx_addr(&mut self, pipe_no: usize, addr: &'a [u8]) -> Result<(), Self::Error>;
+    fn set_rx_addrs(&mut self, pipe_no: usize, addr: &'a [u8]) -> Result<(), Self::Error>;
 
     /// Sets the address to send data to
     fn set_tx_addr(&mut self, addr: &'a [u8]) -> Result<(), Self::Error>;
@@ -213,7 +213,7 @@ pub trait NRF24L01Configuration<'a> {
     fn get_read_enabled_pipes(&self) -> [bool; PIPES_COUNT];
 
     /// Gets the rx addresses of each pipe
-    fn get_rx_addr(&self) -> [&'a [u8]; PIPES_COUNT];
+    fn get_rx_addrs(&self) -> [&'a [u8]; PIPES_COUNT];
 
     /// Gets the tx address
     fn get_tx_addr(&self) -> &'a [u8];

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,20 +1,17 @@
+//! Configuration Parameters for the NRF24L01+ Board
+
 use crate::PIPES_COUNT;
 
 /// Supported air data rates.
-#[derive(Debug, PartialEq, Clone, Copy)]
+#[derive(Debug, PartialEq, Clone, Copy, Default)]
 pub enum DataRate {
     /// 250 Kbps
     R250Kbps,
     /// 1 Mbps
+    #[default]
     R1Mbps,
     /// 2 Mbps
     R2Mbps,
-}
-
-impl Default for DataRate {
-    fn default() -> DataRate {
-        DataRate::R1Mbps
-    }
 }
 
 /// Supported CRC modes
@@ -94,6 +91,7 @@ pub struct NRF24L01Config<'a> {
 
 impl<'a> NRF24L01Config<'a> {
     /// Creates a new instance of NRF24L01Config with given parameters
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         data_rate: DataRate,
         crc_mode: CrcMode,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,20 +16,18 @@ extern crate bitfield;
 use core::fmt;
 use core::fmt::Debug;
 
-use command::FlushRx;
-use config::{NRF24L01Configuration, PALevel, RetransmitConfig};
 use embedded_hal::blocking::spi::Transfer as SpiTransfer;
 use embedded_hal::digital::v2::OutputPin;
-use registers::{RfSetup, EnRxaddr, TxAddr, SetupRetr, EnAa, Dynpd, Feature};
 
 pub mod config;
-pub use crate::config::{CrcMode, DataRate, NRF24L01Config};
+pub use crate::config::{CrcMode, DataRate, NRF24L01Config, NRF24L01Configuration, PALevel, RetransmitConfig};
 pub mod setup;
 
 mod registers;
 use crate::registers::{Config, Register, SetupAw, Status, FifoStatus, CD, RfCh};
+use crate::registers::{RfSetup, EnRxaddr, TxAddr, SetupRetr, EnAa, Dynpd, Feature};
 mod command;
-use crate::command::{Command, ReadRegister, WriteRegister, ReadRxPayloadWidth, ReadRxPayload, WriteTxPayload, FlushTx};
+use crate::command::{Command, ReadRegister, WriteRegister, ReadRxPayloadWidth, ReadRxPayload, WriteTxPayload, FlushTx, FlushRx};
 mod payload;
 pub use crate::payload::Payload;
 mod error;

--- a/src/payload.rs
+++ b/src/payload.rs
@@ -22,6 +22,11 @@ impl Payload {
     pub fn len(&self) -> usize {
         self.len
     }
+
+    /// See if it is an empty payload
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
 }
 
 impl AsRef<[u8]> for Payload {
@@ -33,6 +38,6 @@ impl AsRef<[u8]> for Payload {
 impl Deref for Payload {
     type Target = [u8];
     fn deref(&self) -> &[u8] {
-        &self.as_ref()
+        self.as_ref()
     }
 }


### PR DESCRIPTION
The previous way of configuring the nRF24l01 module made sense based on the previous underlying device being wrapped method.  However, when you want to preserve the device as the actual object it quickly seems a bit obsolete.  Therefore, I kind of reworked the already existing configuration module into a trait instead of a wrapper.